### PR TITLE
👍 外部から使われていない構造体や型名をPrivateに変更

### DIFF
--- a/rule.go
+++ b/rule.go
@@ -2,7 +2,7 @@ package ojosama
 
 import "github.com/ikawaha/kagome/v2/tokenizer"
 
-type Converter struct {
+type convertRule struct {
 	Conditions                   []ConvertCondition
 	BeforeIgnoreConditions       []ConvertCondition // 前のTokenで条件にマッチした場合は無視する
 	AfterIgnoreConditions        []ConvertCondition // 次のTokenで条件にマッチした場合は無視する
@@ -13,7 +13,7 @@ type Converter struct {
 
 // FIXME: 型が不適当
 type MultiConverter struct {
-	Conditions     [][]Converter
+	Conditions     [][]convertRule
 	AppendLongNote bool
 	Value          string
 }
@@ -34,7 +34,7 @@ var (
 	multiConvertRules = []MultiConverter{
 		{
 			Value: "壱百満天原サロメ",
-			Conditions: [][]Converter{
+			Conditions: [][]convertRule{
 				{
 					{
 						Conditions: []ConvertCondition{
@@ -103,7 +103,7 @@ var (
 		{
 			Value:          "いたしますわ",
 			AppendLongNote: true,
-			Conditions: [][]Converter{
+			Conditions: [][]convertRule{
 				{
 					{
 						Conditions: []ConvertCondition{
@@ -135,7 +135,7 @@ var (
 
 		{
 			Value: "ですので",
-			Conditions: [][]Converter{
+			Conditions: [][]convertRule{
 				{
 					{
 						Conditions: []ConvertCondition{
@@ -167,7 +167,7 @@ var (
 
 		{
 			Value: "なんですの",
-			Conditions: [][]Converter{
+			Conditions: [][]convertRule{
 				{
 					{
 						Conditions: []ConvertCondition{
@@ -211,7 +211,7 @@ var (
 
 		{
 			Value: "ですわ",
-			Conditions: [][]Converter{
+			Conditions: [][]convertRule{
 				{
 					{
 						Conditions: []ConvertCondition{
@@ -244,7 +244,7 @@ var (
 
 	// excludeRules は変換処理を無視するルール。
 	// このルールは convertRules よりも優先して評価される。
-	excludeRules = []Converter{
+	excludeRules = []convertRule{
 		{
 			Conditions: []ConvertCondition{
 				{
@@ -259,7 +259,7 @@ var (
 		},
 	}
 
-	convertRules = []Converter{
+	convertRules = []convertRule{
 		{
 			Conditions: []ConvertCondition{
 				{

--- a/rule.go
+++ b/rule.go
@@ -3,9 +3,9 @@ package ojosama
 import "github.com/ikawaha/kagome/v2/tokenizer"
 
 type convertRule struct {
-	Conditions                   []ConvertCondition
-	BeforeIgnoreConditions       []ConvertCondition // 前のTokenで条件にマッチした場合は無視する
-	AfterIgnoreConditions        []ConvertCondition // 次のTokenで条件にマッチした場合は無視する
+	Conditions                   []convertCondition
+	BeforeIgnoreConditions       []convertCondition // 前のTokenで条件にマッチした場合は無視する
+	AfterIgnoreConditions        []convertCondition // 次のTokenで条件にマッチした場合は無視する
 	EnableWhenSentenceSeparation bool               // 文の区切り（単語の後に句点か読点がくる、あるいは何もない）場合だけ有効にする
 	AppendLongNote               bool               // 波線を追加する
 	Value                        string
@@ -20,7 +20,7 @@ type multiConvertRule struct {
 
 type convertType int
 
-type ConvertCondition struct {
+type convertCondition struct {
 	Type  convertType
 	Value []string
 }
@@ -37,7 +37,7 @@ var (
 			Conditions: [][]convertRule{
 				{
 					{
-						Conditions: []ConvertCondition{
+						Conditions: []convertCondition{
 							{
 								Type:  ConvertTypeFeatures,
 								Value: []string{"名詞", "一般"},
@@ -49,7 +49,7 @@ var (
 						},
 					},
 					{
-						Conditions: []ConvertCondition{
+						Conditions: []convertCondition{
 							{
 								Type:  ConvertTypeFeatures,
 								Value: []string{"名詞", "数"},
@@ -61,7 +61,7 @@ var (
 						},
 					},
 					{
-						Conditions: []ConvertCondition{
+						Conditions: []convertCondition{
 							{
 								Type:  ConvertTypeFeatures,
 								Value: []string{"名詞", "一般"},
@@ -73,7 +73,7 @@ var (
 						},
 					},
 					{
-						Conditions: []ConvertCondition{
+						Conditions: []convertCondition{
 							{
 								Type:  ConvertTypeFeatures,
 								Value: []string{"接頭詞", "名詞接続"},
@@ -85,7 +85,7 @@ var (
 						},
 					},
 					{
-						Conditions: []ConvertCondition{
+						Conditions: []convertCondition{
 							{
 								Type:  ConvertTypeFeatures,
 								Value: []string{"名詞", "一般"},
@@ -106,7 +106,7 @@ var (
 			Conditions: [][]convertRule{
 				{
 					{
-						Conditions: []ConvertCondition{
+						Conditions: []convertCondition{
 							{
 								Type:  ConvertTypeFeatures,
 								Value: []string{"動詞", "自立"},
@@ -118,7 +118,7 @@ var (
 						},
 					},
 					{
-						Conditions: []ConvertCondition{
+						Conditions: []convertCondition{
 							{
 								Type:  ConvertTypeFeatures,
 								Value: []string{"助動詞"},
@@ -138,7 +138,7 @@ var (
 			Conditions: [][]convertRule{
 				{
 					{
-						Conditions: []ConvertCondition{
+						Conditions: []convertCondition{
 							{
 								Type:  ConvertTypeFeatures,
 								Value: []string{"助動詞"},
@@ -150,7 +150,7 @@ var (
 						},
 					},
 					{
-						Conditions: []ConvertCondition{
+						Conditions: []convertCondition{
 							{
 								Type:  ConvertTypeFeatures,
 								Value: []string{"助詞", "接続助詞"},
@@ -170,7 +170,7 @@ var (
 			Conditions: [][]convertRule{
 				{
 					{
-						Conditions: []ConvertCondition{
+						Conditions: []convertCondition{
 							{
 								Type:  ConvertTypeFeatures,
 								Value: []string{"助動詞"},
@@ -182,7 +182,7 @@ var (
 						},
 					},
 					{
-						Conditions: []ConvertCondition{
+						Conditions: []convertCondition{
 							{
 								Type:  ConvertTypeFeatures,
 								Value: []string{"名詞", "非自立", "一般"},
@@ -194,7 +194,7 @@ var (
 						},
 					},
 					{
-						Conditions: []ConvertCondition{
+						Conditions: []convertCondition{
 							{
 								Type:  ConvertTypeFeatures,
 								Value: []string{"助動詞"},
@@ -214,7 +214,7 @@ var (
 			Conditions: [][]convertRule{
 				{
 					{
-						Conditions: []ConvertCondition{
+						Conditions: []convertCondition{
 							{
 								Type:  ConvertTypeFeatures,
 								Value: []string{"助動詞"},
@@ -226,7 +226,7 @@ var (
 						},
 					},
 					{
-						Conditions: []ConvertCondition{
+						Conditions: []convertCondition{
 							{
 								Type:  ConvertTypeFeatures,
 								Value: []string{"助詞", "終助詞"},
@@ -246,7 +246,7 @@ var (
 	// このルールは convertRules よりも優先して評価される。
 	excludeRules = []convertRule{
 		{
-			Conditions: []ConvertCondition{
+			Conditions: []convertCondition{
 				{
 					Type:  ConvertTypeFeatures,
 					Value: []string{"名詞", "一般"},
@@ -261,7 +261,7 @@ var (
 
 	convertRules = []convertRule{
 		{
-			Conditions: []ConvertCondition{
+			Conditions: []convertCondition{
 				{
 					Type:  ConvertTypeFeatures,
 					Value: []string{"名詞", "代名詞", "一般"},
@@ -274,7 +274,7 @@ var (
 			Value: "貴方",
 		},
 		{
-			Conditions: []ConvertCondition{
+			Conditions: []convertCondition{
 				{
 					Type:  ConvertTypeFeatures,
 					Value: []string{"名詞", "代名詞", "一般"},
@@ -287,7 +287,7 @@ var (
 			Value: "私",
 		},
 		{
-			Conditions: []ConvertCondition{
+			Conditions: []convertCondition{
 				{
 					Type:  ConvertTypeFeatures,
 					Value: []string{"名詞", "代名詞", "一般"},
@@ -300,7 +300,7 @@ var (
 			Value: "ワタクシ",
 		},
 		{
-			Conditions: []ConvertCondition{
+			Conditions: []convertCondition{
 				{
 					Type:  ConvertTypeFeatures,
 					Value: []string{"名詞", "代名詞", "一般"},
@@ -313,7 +313,7 @@ var (
 			Value: "わたくし",
 		},
 		{
-			Conditions: []ConvertCondition{
+			Conditions: []convertCondition{
 				{
 					Type:  ConvertTypeFeatures,
 					Value: []string{"名詞", "代名詞", "一般"},
@@ -326,7 +326,7 @@ var (
 			Value: "私",
 		},
 		{
-			Conditions: []ConvertCondition{
+			Conditions: []convertCondition{
 				{
 					Type:  ConvertTypeFeatures,
 					Value: []string{"名詞", "代名詞", "一般"},
@@ -339,7 +339,7 @@ var (
 			Value: "ワタクシ",
 		},
 		{
-			Conditions: []ConvertCondition{
+			Conditions: []convertCondition{
 				{
 					Type:  ConvertTypeFeatures,
 					Value: []string{"名詞", "代名詞", "一般"},
@@ -352,7 +352,7 @@ var (
 			Value: "わたくし",
 		},
 		{
-			Conditions: []ConvertCondition{
+			Conditions: []convertCondition{
 				{
 					Type:  ConvertTypeFeatures,
 					Value: []string{"名詞", "代名詞", "一般"},
@@ -365,7 +365,7 @@ var (
 			Value: "わたくし",
 		},
 		{
-			Conditions: []ConvertCondition{
+			Conditions: []convertCondition{
 				{
 					Type:  ConvertTypeFeatures,
 					Value: []string{"名詞", "代名詞", "一般"},
@@ -378,7 +378,7 @@ var (
 			Value: "わたくし",
 		},
 		{
-			Conditions: []ConvertCondition{
+			Conditions: []convertCondition{
 				{
 					Type:  ConvertTypeFeatures,
 					Value: []string{"名詞", "代名詞", "一般"},
@@ -391,7 +391,7 @@ var (
 			Value: "どちら",
 		},
 		{
-			Conditions: []ConvertCondition{
+			Conditions: []convertCondition{
 				{
 					Type:  ConvertTypeFeatures,
 					Value: []string{"名詞", "非自立", "一般"},
@@ -404,7 +404,7 @@ var (
 			Value: "もの",
 		},
 		{
-			Conditions: []ConvertCondition{
+			Conditions: []convertCondition{
 				{
 					Type:  ConvertTypeFeatures,
 					Value: []string{"助動詞"},
@@ -414,7 +414,7 @@ var (
 					Value: []string{"です"},
 				},
 			},
-			AfterIgnoreConditions: []ConvertCondition{
+			AfterIgnoreConditions: []convertCondition{
 				{
 					Type:  ConvertTypeFeatures,
 					Value: []string{"助詞", "副助詞／並立助詞／終助詞"},
@@ -424,7 +424,7 @@ var (
 			Value:          "ですわ",
 		},
 		{
-			Conditions: []ConvertCondition{
+			Conditions: []convertCondition{
 				{
 					Type:  ConvertTypeFeatures,
 					Value: []string{"助動詞"},
@@ -434,7 +434,7 @@ var (
 					Value: []string{"だ"},
 				},
 			},
-			AfterIgnoreConditions: []ConvertCondition{
+			AfterIgnoreConditions: []convertCondition{
 				{
 					Type:  ConvertTypeFeatures,
 					Value: []string{"助詞", "副助詞／並立助詞／終助詞"},
@@ -444,7 +444,7 @@ var (
 			Value:          "ですわ",
 		},
 		{
-			Conditions: []ConvertCondition{
+			Conditions: []convertCondition{
 				{
 					Type:  ConvertTypeFeatures,
 					Value: []string{"動詞", "自立"},
@@ -459,7 +459,7 @@ var (
 			Value:                        "いたしますわ",
 		},
 		{
-			Conditions: []ConvertCondition{
+			Conditions: []convertCondition{
 				{
 					Type:  ConvertTypeFeatures,
 					Value: []string{"動詞", "自立"},
@@ -474,7 +474,7 @@ var (
 			Value:                        "なりますわ",
 		},
 		{
-			Conditions: []ConvertCondition{
+			Conditions: []convertCondition{
 				{
 					Type:  ConvertTypeFeatures,
 					Value: []string{"動詞", "自立"},
@@ -487,7 +487,7 @@ var (
 			Value: "あります",
 		},
 		{
-			Conditions: []ConvertCondition{
+			Conditions: []convertCondition{
 				{
 					Type:  ConvertTypeFeatures,
 					Value: []string{"助詞", "副助詞"},
@@ -500,7 +500,7 @@ var (
 			Value: "では",
 		},
 		{
-			Conditions: []ConvertCondition{
+			Conditions: []convertCondition{
 				{
 					Type:  ConvertTypeFeatures,
 					Value: []string{"助詞", "副助詞／並立助詞／終助詞"},
@@ -513,7 +513,7 @@ var (
 			Value: "の",
 		},
 		{
-			Conditions: []ConvertCondition{
+			Conditions: []convertCondition{
 				{
 					Type:  ConvertTypeFeatures,
 					Value: []string{"助詞", "終助詞"},
@@ -527,7 +527,7 @@ var (
 			Value:          "ですわ",
 		},
 		{
-			Conditions: []ConvertCondition{
+			Conditions: []convertCondition{
 				{
 					Type:  ConvertTypeFeatures,
 					Value: []string{"助詞", "終助詞"},
@@ -540,7 +540,7 @@ var (
 			Value: "ね",
 		},
 		{
-			Conditions: []ConvertCondition{
+			Conditions: []convertCondition{
 				{
 					Type:  ConvertTypeFeatures,
 					Value: []string{"助詞", "終助詞"},
@@ -553,7 +553,7 @@ var (
 			Value: "",
 		},
 		{
-			Conditions: []ConvertCondition{
+			Conditions: []convertCondition{
 				{
 					Type:  ConvertTypeFeatures,
 					Value: []string{"助詞", "接続助詞"},
@@ -566,7 +566,7 @@ var (
 			Value: "ので",
 		},
 		{
-			Conditions: []ConvertCondition{
+			Conditions: []convertCondition{
 				{
 					Type:  ConvertTypeFeatures,
 					Value: []string{"助詞", "接続助詞"},
@@ -579,7 +579,7 @@ var (
 			Value: "けれど",
 		},
 		{
-			Conditions: []ConvertCondition{
+			Conditions: []convertCondition{
 				{
 					Type:  ConvertTypeFeatures,
 					Value: []string{"助詞", "接続助詞"},
@@ -592,7 +592,7 @@ var (
 			Value: "ですし",
 		},
 		{
-			Conditions: []ConvertCondition{
+			Conditions: []convertCondition{
 				{
 					Type:  ConvertTypeFeatures,
 					Value: []string{"助動詞"},
@@ -602,7 +602,7 @@ var (
 					Value: []string{"まし"},
 				},
 			},
-			BeforeIgnoreConditions: []ConvertCondition{
+			BeforeIgnoreConditions: []convertCondition{
 				{
 					Type:  ConvertTypeFeatures,
 					Value: []string{"動詞", "自立"},
@@ -611,7 +611,7 @@ var (
 			Value: "おりまし",
 		},
 		{
-			Conditions: []ConvertCondition{
+			Conditions: []convertCondition{
 				{
 					Type:  ConvertTypeFeatures,
 					Value: []string{"助動詞"},
@@ -625,7 +625,7 @@ var (
 			Value:          "ますわ",
 		},
 		{
-			Conditions: []ConvertCondition{
+			Conditions: []convertCondition{
 				{
 					Type:  ConvertTypeFeatures,
 					Value: []string{"助動詞"},
@@ -640,7 +640,7 @@ var (
 			Value:                        "たわ",
 		},
 		{
-			Conditions: []ConvertCondition{
+			Conditions: []convertCondition{
 				{
 					Type:  ConvertTypeFeatures,
 					Value: []string{"助動詞"},
@@ -653,7 +653,7 @@ var (
 			Value: "でしょう",
 		},
 		{
-			Conditions: []ConvertCondition{
+			Conditions: []convertCondition{
 				{
 					Type:  ConvertTypeFeatures,
 					Value: []string{"助動詞"},
@@ -663,7 +663,7 @@ var (
 					Value: []string{"ない"},
 				},
 			},
-			BeforeIgnoreConditions: []ConvertCondition{
+			BeforeIgnoreConditions: []convertCondition{
 				{
 					Type:  ConvertTypeFeatures,
 					Value: []string{"動詞", "自立"},
@@ -672,7 +672,7 @@ var (
 			Value: "ありません",
 		},
 		{
-			Conditions: []ConvertCondition{
+			Conditions: []convertCondition{
 				{
 					Type:  ConvertTypeFeatures,
 					Value: []string{"動詞", "非自立"},
@@ -685,7 +685,7 @@ var (
 			Value: "くださいまし",
 		},
 		{
-			Conditions: []ConvertCondition{
+			Conditions: []convertCondition{
 				{
 					Type:  ConvertTypeFeatures,
 					Value: []string{"動詞", "非自立"},
@@ -698,7 +698,7 @@ var (
 			Value: "くださいまし",
 		},
 		{
-			Conditions: []ConvertCondition{
+			Conditions: []convertCondition{
 				{
 					Type:  ConvertTypeFeatures,
 					Value: []string{"感動詞"},
@@ -711,7 +711,7 @@ var (
 			Value: "ありがとうございますわ",
 		},
 		{
-			Conditions: []ConvertCondition{
+			Conditions: []convertCondition{
 				{
 					Type:  ConvertTypeFeatures,
 					Value: []string{"感動詞"},
@@ -724,7 +724,7 @@ var (
 			Value: "それでは",
 		},
 		{
-			Conditions: []ConvertCondition{
+			Conditions: []convertCondition{
 				{
 					Type:  ConvertTypeFeatures,
 					Value: []string{"感動詞"},
@@ -737,7 +737,7 @@ var (
 			Value: "それでは",
 		},
 		{
-			Conditions: []ConvertCondition{
+			Conditions: []convertCondition{
 				{
 					Type:  ConvertTypeFeatures,
 					Value: []string{"動詞", "非自立"},
@@ -750,7 +750,7 @@ var (
 			Value: "くれます",
 		},
 		{
-			Conditions: []ConvertCondition{
+			Conditions: []convertCondition{
 				{
 					Type:  ConvertTypeFeatures,
 					Value: []string{"形容詞", "自立"},
@@ -763,7 +763,7 @@ var (
 			Value: "きったねぇ",
 		},
 		{
-			Conditions: []ConvertCondition{
+			Conditions: []convertCondition{
 				{
 					Type:  ConvertTypeFeatures,
 					Value: []string{"形容詞", "自立"},
@@ -776,7 +776,7 @@ var (
 			Value: "きったねぇ",
 		},
 		{
-			Conditions: []ConvertCondition{
+			Conditions: []convertCondition{
 				{
 					Type:  ConvertTypeFeatures,
 					Value: []string{"形容詞", "自立"},
@@ -789,7 +789,7 @@ var (
 			Value: "くっせぇ",
 		},
 		{
-			Conditions: []ConvertCondition{
+			Conditions: []convertCondition{
 				{
 					Type:  ConvertTypeFeatures,
 					Value: []string{"形容詞", "自立"},
@@ -802,7 +802,7 @@ var (
 			Value: "くっせぇ",
 		},
 		{
-			Conditions: []ConvertCondition{
+			Conditions: []convertCondition{
 				{
 					Type:  ConvertTypeFeatures,
 					Value: []string{"感動詞"},
@@ -815,7 +815,7 @@ var (
 			Value: "おほ",
 		},
 		{
-			Conditions: []ConvertCondition{
+			Conditions: []convertCondition{
 				{
 					Type:  ConvertTypeFeatures,
 					Value: []string{"感動詞"},
@@ -828,7 +828,7 @@ var (
 			Value: "おほほ",
 		},
 		{
-			Conditions: []ConvertCondition{
+			Conditions: []convertCondition{
 				{
 					Type:  ConvertTypeFeatures,
 					Value: []string{"感動詞"},
@@ -841,7 +841,7 @@ var (
 			Value: "お",
 		},
 		{
-			Conditions: []ConvertCondition{
+			Conditions: []convertCondition{
 				{
 					Type:  ConvertTypeFeatures,
 					Value: []string{"感動詞"},
@@ -856,7 +856,7 @@ var (
 	}
 )
 
-func (c *ConvertCondition) equalsTokenData(data tokenizer.TokenData) bool {
+func (c *convertCondition) equalsTokenData(data tokenizer.TokenData) bool {
 	switch c.Type {
 	case ConvertTypeFeatures:
 		if equalsFeatures(data.Features, c.Value) {
@@ -870,7 +870,7 @@ func (c *ConvertCondition) equalsTokenData(data tokenizer.TokenData) bool {
 	return false
 }
 
-func (c *ConvertCondition) notEqualsTokenData(data tokenizer.TokenData) bool {
+func (c *convertCondition) notEqualsTokenData(data tokenizer.TokenData) bool {
 	switch c.Type {
 	case ConvertTypeFeatures:
 		if !equalsFeatures(data.Features, c.Value) {

--- a/rule.go
+++ b/rule.go
@@ -12,7 +12,7 @@ type convertRule struct {
 }
 
 // FIXME: 型が不適当
-type MultiConverter struct {
+type multiConvertRule struct {
 	Conditions     [][]convertRule
 	AppendLongNote bool
 	Value          string
@@ -31,7 +31,7 @@ const (
 )
 
 var (
-	multiConvertRules = []MultiConverter{
+	multiConvertRules = []multiConvertRule{
 		{
 			Value: "壱百満天原サロメ",
 			Conditions: [][]convertRule{

--- a/rule.go
+++ b/rule.go
@@ -26,8 +26,8 @@ type convertCondition struct {
 }
 
 const (
-	ConvertTypeSurface convertType = iota + 1
-	ConvertTypeFeatures
+	convertTypeSurface convertType = iota + 1
+	convertTypeFeatures
 )
 
 var (
@@ -39,11 +39,11 @@ var (
 					{
 						Conditions: []convertCondition{
 							{
-								Type:  ConvertTypeFeatures,
+								Type:  convertTypeFeatures,
 								Value: []string{"名詞", "一般"},
 							},
 							{
-								Type:  ConvertTypeSurface,
+								Type:  convertTypeSurface,
 								Value: []string{"壱"},
 							},
 						},
@@ -51,11 +51,11 @@ var (
 					{
 						Conditions: []convertCondition{
 							{
-								Type:  ConvertTypeFeatures,
+								Type:  convertTypeFeatures,
 								Value: []string{"名詞", "数"},
 							},
 							{
-								Type:  ConvertTypeSurface,
+								Type:  convertTypeSurface,
 								Value: []string{"百"},
 							},
 						},
@@ -63,11 +63,11 @@ var (
 					{
 						Conditions: []convertCondition{
 							{
-								Type:  ConvertTypeFeatures,
+								Type:  convertTypeFeatures,
 								Value: []string{"名詞", "一般"},
 							},
 							{
-								Type:  ConvertTypeSurface,
+								Type:  convertTypeSurface,
 								Value: []string{"満天"},
 							},
 						},
@@ -75,11 +75,11 @@ var (
 					{
 						Conditions: []convertCondition{
 							{
-								Type:  ConvertTypeFeatures,
+								Type:  convertTypeFeatures,
 								Value: []string{"接頭詞", "名詞接続"},
 							},
 							{
-								Type:  ConvertTypeSurface,
+								Type:  convertTypeSurface,
 								Value: []string{"原"},
 							},
 						},
@@ -87,11 +87,11 @@ var (
 					{
 						Conditions: []convertCondition{
 							{
-								Type:  ConvertTypeFeatures,
+								Type:  convertTypeFeatures,
 								Value: []string{"名詞", "一般"},
 							},
 							{
-								Type:  ConvertTypeSurface,
+								Type:  convertTypeSurface,
 								Value: []string{"サロメ"},
 							},
 						},
@@ -108,11 +108,11 @@ var (
 					{
 						Conditions: []convertCondition{
 							{
-								Type:  ConvertTypeFeatures,
+								Type:  convertTypeFeatures,
 								Value: []string{"動詞", "自立"},
 							},
 							{
-								Type:  ConvertTypeSurface,
+								Type:  convertTypeSurface,
 								Value: []string{"し"},
 							},
 						},
@@ -120,11 +120,11 @@ var (
 					{
 						Conditions: []convertCondition{
 							{
-								Type:  ConvertTypeFeatures,
+								Type:  convertTypeFeatures,
 								Value: []string{"助動詞"},
 							},
 							{
-								Type:  ConvertTypeSurface,
+								Type:  convertTypeSurface,
 								Value: []string{"ます"},
 							},
 						},
@@ -140,11 +140,11 @@ var (
 					{
 						Conditions: []convertCondition{
 							{
-								Type:  ConvertTypeFeatures,
+								Type:  convertTypeFeatures,
 								Value: []string{"助動詞"},
 							},
 							{
-								Type:  ConvertTypeSurface,
+								Type:  convertTypeSurface,
 								Value: []string{"だ"},
 							},
 						},
@@ -152,11 +152,11 @@ var (
 					{
 						Conditions: []convertCondition{
 							{
-								Type:  ConvertTypeFeatures,
+								Type:  convertTypeFeatures,
 								Value: []string{"助詞", "接続助詞"},
 							},
 							{
-								Type:  ConvertTypeSurface,
+								Type:  convertTypeSurface,
 								Value: []string{"から"},
 							},
 						},
@@ -172,11 +172,11 @@ var (
 					{
 						Conditions: []convertCondition{
 							{
-								Type:  ConvertTypeFeatures,
+								Type:  convertTypeFeatures,
 								Value: []string{"助動詞"},
 							},
 							{
-								Type:  ConvertTypeSurface,
+								Type:  convertTypeSurface,
 								Value: []string{"な"},
 							},
 						},
@@ -184,11 +184,11 @@ var (
 					{
 						Conditions: []convertCondition{
 							{
-								Type:  ConvertTypeFeatures,
+								Type:  convertTypeFeatures,
 								Value: []string{"名詞", "非自立", "一般"},
 							},
 							{
-								Type:  ConvertTypeSurface,
+								Type:  convertTypeSurface,
 								Value: []string{"ん"},
 							},
 						},
@@ -196,11 +196,11 @@ var (
 					{
 						Conditions: []convertCondition{
 							{
-								Type:  ConvertTypeFeatures,
+								Type:  convertTypeFeatures,
 								Value: []string{"助動詞"},
 							},
 							{
-								Type:  ConvertTypeSurface,
+								Type:  convertTypeSurface,
 								Value: []string{"だ"},
 							},
 						},
@@ -216,11 +216,11 @@ var (
 					{
 						Conditions: []convertCondition{
 							{
-								Type:  ConvertTypeFeatures,
+								Type:  convertTypeFeatures,
 								Value: []string{"助動詞"},
 							},
 							{
-								Type:  ConvertTypeSurface,
+								Type:  convertTypeSurface,
 								Value: []string{"だ"},
 							},
 						},
@@ -228,11 +228,11 @@ var (
 					{
 						Conditions: []convertCondition{
 							{
-								Type:  ConvertTypeFeatures,
+								Type:  convertTypeFeatures,
 								Value: []string{"助詞", "終助詞"},
 							},
 							{
-								Type:  ConvertTypeSurface,
+								Type:  convertTypeSurface,
 								Value: []string{"よ"},
 							},
 						},
@@ -248,11 +248,11 @@ var (
 		{
 			Conditions: []convertCondition{
 				{
-					Type:  ConvertTypeFeatures,
+					Type:  convertTypeFeatures,
 					Value: []string{"名詞", "一般"},
 				},
 				{
-					Type:  ConvertTypeSurface,
+					Type:  convertTypeSurface,
 					Value: []string{"お嬢様"},
 				},
 			},
@@ -263,11 +263,11 @@ var (
 		{
 			Conditions: []convertCondition{
 				{
-					Type:  ConvertTypeFeatures,
+					Type:  convertTypeFeatures,
 					Value: []string{"名詞", "代名詞", "一般"},
 				},
 				{
-					Type:  ConvertTypeSurface,
+					Type:  convertTypeSurface,
 					Value: []string{"あなた"},
 				},
 			},
@@ -276,11 +276,11 @@ var (
 		{
 			Conditions: []convertCondition{
 				{
-					Type:  ConvertTypeFeatures,
+					Type:  convertTypeFeatures,
 					Value: []string{"名詞", "代名詞", "一般"},
 				},
 				{
-					Type:  ConvertTypeSurface,
+					Type:  convertTypeSurface,
 					Value: []string{"俺"},
 				},
 			},
@@ -289,11 +289,11 @@ var (
 		{
 			Conditions: []convertCondition{
 				{
-					Type:  ConvertTypeFeatures,
+					Type:  convertTypeFeatures,
 					Value: []string{"名詞", "代名詞", "一般"},
 				},
 				{
-					Type:  ConvertTypeSurface,
+					Type:  convertTypeSurface,
 					Value: []string{"オレ"},
 				},
 			},
@@ -302,11 +302,11 @@ var (
 		{
 			Conditions: []convertCondition{
 				{
-					Type:  ConvertTypeFeatures,
+					Type:  convertTypeFeatures,
 					Value: []string{"名詞", "代名詞", "一般"},
 				},
 				{
-					Type:  ConvertTypeSurface,
+					Type:  convertTypeSurface,
 					Value: []string{"おれ"},
 				},
 			},
@@ -315,11 +315,11 @@ var (
 		{
 			Conditions: []convertCondition{
 				{
-					Type:  ConvertTypeFeatures,
+					Type:  convertTypeFeatures,
 					Value: []string{"名詞", "代名詞", "一般"},
 				},
 				{
-					Type:  ConvertTypeSurface,
+					Type:  convertTypeSurface,
 					Value: []string{"僕"},
 				},
 			},
@@ -328,11 +328,11 @@ var (
 		{
 			Conditions: []convertCondition{
 				{
-					Type:  ConvertTypeFeatures,
+					Type:  convertTypeFeatures,
 					Value: []string{"名詞", "代名詞", "一般"},
 				},
 				{
-					Type:  ConvertTypeSurface,
+					Type:  convertTypeSurface,
 					Value: []string{"ボク"},
 				},
 			},
@@ -341,11 +341,11 @@ var (
 		{
 			Conditions: []convertCondition{
 				{
-					Type:  ConvertTypeFeatures,
+					Type:  convertTypeFeatures,
 					Value: []string{"名詞", "代名詞", "一般"},
 				},
 				{
-					Type:  ConvertTypeSurface,
+					Type:  convertTypeSurface,
 					Value: []string{"ぼく"},
 				},
 			},
@@ -354,11 +354,11 @@ var (
 		{
 			Conditions: []convertCondition{
 				{
-					Type:  ConvertTypeFeatures,
+					Type:  convertTypeFeatures,
 					Value: []string{"名詞", "代名詞", "一般"},
 				},
 				{
-					Type:  ConvertTypeSurface,
+					Type:  convertTypeSurface,
 					Value: []string{"あたし"},
 				},
 			},
@@ -367,11 +367,11 @@ var (
 		{
 			Conditions: []convertCondition{
 				{
-					Type:  ConvertTypeFeatures,
+					Type:  convertTypeFeatures,
 					Value: []string{"名詞", "代名詞", "一般"},
 				},
 				{
-					Type:  ConvertTypeSurface,
+					Type:  convertTypeSurface,
 					Value: []string{"わたし"},
 				},
 			},
@@ -380,11 +380,11 @@ var (
 		{
 			Conditions: []convertCondition{
 				{
-					Type:  ConvertTypeFeatures,
+					Type:  convertTypeFeatures,
 					Value: []string{"名詞", "代名詞", "一般"},
 				},
 				{
-					Type:  ConvertTypeSurface,
+					Type:  convertTypeSurface,
 					Value: []string{"どこ"},
 				},
 			},
@@ -393,11 +393,11 @@ var (
 		{
 			Conditions: []convertCondition{
 				{
-					Type:  ConvertTypeFeatures,
+					Type:  convertTypeFeatures,
 					Value: []string{"名詞", "非自立", "一般"},
 				},
 				{
-					Type:  ConvertTypeSurface,
+					Type:  convertTypeSurface,
 					Value: []string{"もん"},
 				},
 			},
@@ -406,17 +406,17 @@ var (
 		{
 			Conditions: []convertCondition{
 				{
-					Type:  ConvertTypeFeatures,
+					Type:  convertTypeFeatures,
 					Value: []string{"助動詞"},
 				},
 				{
-					Type:  ConvertTypeSurface,
+					Type:  convertTypeSurface,
 					Value: []string{"です"},
 				},
 			},
 			AfterIgnoreConditions: []convertCondition{
 				{
-					Type:  ConvertTypeFeatures,
+					Type:  convertTypeFeatures,
 					Value: []string{"助詞", "副助詞／並立助詞／終助詞"},
 				},
 			},
@@ -426,17 +426,17 @@ var (
 		{
 			Conditions: []convertCondition{
 				{
-					Type:  ConvertTypeFeatures,
+					Type:  convertTypeFeatures,
 					Value: []string{"助動詞"},
 				},
 				{
-					Type:  ConvertTypeSurface,
+					Type:  convertTypeSurface,
 					Value: []string{"だ"},
 				},
 			},
 			AfterIgnoreConditions: []convertCondition{
 				{
-					Type:  ConvertTypeFeatures,
+					Type:  convertTypeFeatures,
 					Value: []string{"助詞", "副助詞／並立助詞／終助詞"},
 				},
 			},
@@ -446,11 +446,11 @@ var (
 		{
 			Conditions: []convertCondition{
 				{
-					Type:  ConvertTypeFeatures,
+					Type:  convertTypeFeatures,
 					Value: []string{"動詞", "自立"},
 				},
 				{
-					Type:  ConvertTypeSurface,
+					Type:  convertTypeSurface,
 					Value: []string{"する"},
 				},
 			},
@@ -461,11 +461,11 @@ var (
 		{
 			Conditions: []convertCondition{
 				{
-					Type:  ConvertTypeFeatures,
+					Type:  convertTypeFeatures,
 					Value: []string{"動詞", "自立"},
 				},
 				{
-					Type:  ConvertTypeSurface,
+					Type:  convertTypeSurface,
 					Value: []string{"なる"},
 				},
 			},
@@ -476,11 +476,11 @@ var (
 		{
 			Conditions: []convertCondition{
 				{
-					Type:  ConvertTypeFeatures,
+					Type:  convertTypeFeatures,
 					Value: []string{"動詞", "自立"},
 				},
 				{
-					Type:  ConvertTypeSurface,
+					Type:  convertTypeSurface,
 					Value: []string{"ある"},
 				},
 			},
@@ -489,11 +489,11 @@ var (
 		{
 			Conditions: []convertCondition{
 				{
-					Type:  ConvertTypeFeatures,
+					Type:  convertTypeFeatures,
 					Value: []string{"助詞", "副助詞"},
 				},
 				{
-					Type:  ConvertTypeSurface,
+					Type:  convertTypeSurface,
 					Value: []string{"じゃ"},
 				},
 			},
@@ -502,11 +502,11 @@ var (
 		{
 			Conditions: []convertCondition{
 				{
-					Type:  ConvertTypeFeatures,
+					Type:  convertTypeFeatures,
 					Value: []string{"助詞", "副助詞／並立助詞／終助詞"},
 				},
 				{
-					Type:  ConvertTypeSurface,
+					Type:  convertTypeSurface,
 					Value: []string{"か"},
 				},
 			},
@@ -515,11 +515,11 @@ var (
 		{
 			Conditions: []convertCondition{
 				{
-					Type:  ConvertTypeFeatures,
+					Type:  convertTypeFeatures,
 					Value: []string{"助詞", "終助詞"},
 				},
 				{
-					Type:  ConvertTypeSurface,
+					Type:  convertTypeSurface,
 					Value: []string{"わ"},
 				},
 			},
@@ -529,11 +529,11 @@ var (
 		{
 			Conditions: []convertCondition{
 				{
-					Type:  ConvertTypeFeatures,
+					Type:  convertTypeFeatures,
 					Value: []string{"助詞", "終助詞"},
 				},
 				{
-					Type:  ConvertTypeSurface,
+					Type:  convertTypeSurface,
 					Value: []string{"な"},
 				},
 			},
@@ -542,11 +542,11 @@ var (
 		{
 			Conditions: []convertCondition{
 				{
-					Type:  ConvertTypeFeatures,
+					Type:  convertTypeFeatures,
 					Value: []string{"助詞", "終助詞"},
 				},
 				{
-					Type:  ConvertTypeSurface,
+					Type:  convertTypeSurface,
 					Value: []string{"さ"},
 				},
 			},
@@ -555,11 +555,11 @@ var (
 		{
 			Conditions: []convertCondition{
 				{
-					Type:  ConvertTypeFeatures,
+					Type:  convertTypeFeatures,
 					Value: []string{"助詞", "接続助詞"},
 				},
 				{
-					Type:  ConvertTypeSurface,
+					Type:  convertTypeSurface,
 					Value: []string{"から"},
 				},
 			},
@@ -568,11 +568,11 @@ var (
 		{
 			Conditions: []convertCondition{
 				{
-					Type:  ConvertTypeFeatures,
+					Type:  convertTypeFeatures,
 					Value: []string{"助詞", "接続助詞"},
 				},
 				{
-					Type:  ConvertTypeSurface,
+					Type:  convertTypeSurface,
 					Value: []string{"けど"},
 				},
 			},
@@ -581,11 +581,11 @@ var (
 		{
 			Conditions: []convertCondition{
 				{
-					Type:  ConvertTypeFeatures,
+					Type:  convertTypeFeatures,
 					Value: []string{"助詞", "接続助詞"},
 				},
 				{
-					Type:  ConvertTypeSurface,
+					Type:  convertTypeSurface,
 					Value: []string{"し"},
 				},
 			},
@@ -594,17 +594,17 @@ var (
 		{
 			Conditions: []convertCondition{
 				{
-					Type:  ConvertTypeFeatures,
+					Type:  convertTypeFeatures,
 					Value: []string{"助動詞"},
 				},
 				{
-					Type:  ConvertTypeSurface,
+					Type:  convertTypeSurface,
 					Value: []string{"まし"},
 				},
 			},
 			BeforeIgnoreConditions: []convertCondition{
 				{
-					Type:  ConvertTypeFeatures,
+					Type:  convertTypeFeatures,
 					Value: []string{"動詞", "自立"},
 				},
 			},
@@ -613,11 +613,11 @@ var (
 		{
 			Conditions: []convertCondition{
 				{
-					Type:  ConvertTypeFeatures,
+					Type:  convertTypeFeatures,
 					Value: []string{"助動詞"},
 				},
 				{
-					Type:  ConvertTypeSurface,
+					Type:  convertTypeSurface,
 					Value: []string{"ます"},
 				},
 			},
@@ -627,11 +627,11 @@ var (
 		{
 			Conditions: []convertCondition{
 				{
-					Type:  ConvertTypeFeatures,
+					Type:  convertTypeFeatures,
 					Value: []string{"助動詞"},
 				},
 				{
-					Type:  ConvertTypeSurface,
+					Type:  convertTypeSurface,
 					Value: []string{"た"},
 				},
 			},
@@ -642,11 +642,11 @@ var (
 		{
 			Conditions: []convertCondition{
 				{
-					Type:  ConvertTypeFeatures,
+					Type:  convertTypeFeatures,
 					Value: []string{"助動詞"},
 				},
 				{
-					Type:  ConvertTypeSurface,
+					Type:  convertTypeSurface,
 					Value: []string{"だろ"},
 				},
 			},
@@ -655,17 +655,17 @@ var (
 		{
 			Conditions: []convertCondition{
 				{
-					Type:  ConvertTypeFeatures,
+					Type:  convertTypeFeatures,
 					Value: []string{"助動詞"},
 				},
 				{
-					Type:  ConvertTypeSurface,
+					Type:  convertTypeSurface,
 					Value: []string{"ない"},
 				},
 			},
 			BeforeIgnoreConditions: []convertCondition{
 				{
-					Type:  ConvertTypeFeatures,
+					Type:  convertTypeFeatures,
 					Value: []string{"動詞", "自立"},
 				},
 			},
@@ -674,11 +674,11 @@ var (
 		{
 			Conditions: []convertCondition{
 				{
-					Type:  ConvertTypeFeatures,
+					Type:  convertTypeFeatures,
 					Value: []string{"動詞", "非自立"},
 				},
 				{
-					Type:  ConvertTypeSurface,
+					Type:  convertTypeSurface,
 					Value: []string{"ください"},
 				},
 			},
@@ -687,11 +687,11 @@ var (
 		{
 			Conditions: []convertCondition{
 				{
-					Type:  ConvertTypeFeatures,
+					Type:  convertTypeFeatures,
 					Value: []string{"動詞", "非自立"},
 				},
 				{
-					Type:  ConvertTypeSurface,
+					Type:  convertTypeSurface,
 					Value: []string{"くれ"},
 				},
 			},
@@ -700,11 +700,11 @@ var (
 		{
 			Conditions: []convertCondition{
 				{
-					Type:  ConvertTypeFeatures,
+					Type:  convertTypeFeatures,
 					Value: []string{"感動詞"},
 				},
 				{
-					Type:  ConvertTypeSurface,
+					Type:  convertTypeSurface,
 					Value: []string{"ありがとう"},
 				},
 			},
@@ -713,11 +713,11 @@ var (
 		{
 			Conditions: []convertCondition{
 				{
-					Type:  ConvertTypeFeatures,
+					Type:  convertTypeFeatures,
 					Value: []string{"感動詞"},
 				},
 				{
-					Type:  ConvertTypeSurface,
+					Type:  convertTypeSurface,
 					Value: []string{"じゃぁ"},
 				},
 			},
@@ -726,11 +726,11 @@ var (
 		{
 			Conditions: []convertCondition{
 				{
-					Type:  ConvertTypeFeatures,
+					Type:  convertTypeFeatures,
 					Value: []string{"感動詞"},
 				},
 				{
-					Type:  ConvertTypeSurface,
+					Type:  convertTypeSurface,
 					Value: []string{"じゃあ"},
 				},
 			},
@@ -739,11 +739,11 @@ var (
 		{
 			Conditions: []convertCondition{
 				{
-					Type:  ConvertTypeFeatures,
+					Type:  convertTypeFeatures,
 					Value: []string{"動詞", "非自立"},
 				},
 				{
-					Type:  ConvertTypeSurface,
+					Type:  convertTypeSurface,
 					Value: []string{"くれる"},
 				},
 			},
@@ -752,11 +752,11 @@ var (
 		{
 			Conditions: []convertCondition{
 				{
-					Type:  ConvertTypeFeatures,
+					Type:  convertTypeFeatures,
 					Value: []string{"形容詞", "自立"},
 				},
 				{
-					Type:  ConvertTypeSurface,
+					Type:  convertTypeSurface,
 					Value: []string{"汚い"},
 				},
 			},
@@ -765,11 +765,11 @@ var (
 		{
 			Conditions: []convertCondition{
 				{
-					Type:  ConvertTypeFeatures,
+					Type:  convertTypeFeatures,
 					Value: []string{"形容詞", "自立"},
 				},
 				{
-					Type:  ConvertTypeSurface,
+					Type:  convertTypeSurface,
 					Value: []string{"きたない"},
 				},
 			},
@@ -778,11 +778,11 @@ var (
 		{
 			Conditions: []convertCondition{
 				{
-					Type:  ConvertTypeFeatures,
+					Type:  convertTypeFeatures,
 					Value: []string{"形容詞", "自立"},
 				},
 				{
-					Type:  ConvertTypeSurface,
+					Type:  convertTypeSurface,
 					Value: []string{"臭い"},
 				},
 			},
@@ -791,11 +791,11 @@ var (
 		{
 			Conditions: []convertCondition{
 				{
-					Type:  ConvertTypeFeatures,
+					Type:  convertTypeFeatures,
 					Value: []string{"形容詞", "自立"},
 				},
 				{
-					Type:  ConvertTypeSurface,
+					Type:  convertTypeSurface,
 					Value: []string{"くさい"},
 				},
 			},
@@ -804,11 +804,11 @@ var (
 		{
 			Conditions: []convertCondition{
 				{
-					Type:  ConvertTypeFeatures,
+					Type:  convertTypeFeatures,
 					Value: []string{"感動詞"},
 				},
 				{
-					Type:  ConvertTypeSurface,
+					Type:  convertTypeSurface,
 					Value: []string{"うふ"},
 				},
 			},
@@ -817,11 +817,11 @@ var (
 		{
 			Conditions: []convertCondition{
 				{
-					Type:  ConvertTypeFeatures,
+					Type:  convertTypeFeatures,
 					Value: []string{"感動詞"},
 				},
 				{
-					Type:  ConvertTypeSurface,
+					Type:  convertTypeSurface,
 					Value: []string{"うふふ"},
 				},
 			},
@@ -830,11 +830,11 @@ var (
 		{
 			Conditions: []convertCondition{
 				{
-					Type:  ConvertTypeFeatures,
+					Type:  convertTypeFeatures,
 					Value: []string{"感動詞"},
 				},
 				{
-					Type:  ConvertTypeSurface,
+					Type:  convertTypeSurface,
 					Value: []string{"う"},
 				},
 			},
@@ -843,11 +843,11 @@ var (
 		{
 			Conditions: []convertCondition{
 				{
-					Type:  ConvertTypeFeatures,
+					Type:  convertTypeFeatures,
 					Value: []string{"感動詞"},
 				},
 				{
-					Type:  ConvertTypeSurface,
+					Type:  convertTypeSurface,
 					Value: []string{"ふふふ"},
 				},
 			},
@@ -858,11 +858,11 @@ var (
 
 func (c *convertCondition) equalsTokenData(data tokenizer.TokenData) bool {
 	switch c.Type {
-	case ConvertTypeFeatures:
+	case convertTypeFeatures:
 		if equalsFeatures(data.Features, c.Value) {
 			return true
 		}
-	case ConvertTypeSurface:
+	case convertTypeSurface:
 		if data.Surface == c.Value[0] {
 			return true
 		}
@@ -872,11 +872,11 @@ func (c *convertCondition) equalsTokenData(data tokenizer.TokenData) bool {
 
 func (c *convertCondition) notEqualsTokenData(data tokenizer.TokenData) bool {
 	switch c.Type {
-	case ConvertTypeFeatures:
+	case convertTypeFeatures:
 		if !equalsFeatures(data.Features, c.Value) {
 			return true
 		}
-	case ConvertTypeSurface:
+	case convertTypeSurface:
 		if data.Surface != c.Value[0] {
 			return true
 		}

--- a/rule.go
+++ b/rule.go
@@ -18,15 +18,15 @@ type multiConvertRule struct {
 	Value          string
 }
 
-type ConvertType int
+type convertType int
 
 type ConvertCondition struct {
-	Type  ConvertType
+	Type  convertType
 	Value []string
 }
 
 const (
-	ConvertTypeSurface ConvertType = iota + 1
+	ConvertTypeSurface convertType = iota + 1
 	ConvertTypeFeatures
 )
 


### PR DESCRIPTION
意味もなくPublicにしていたので、Privateに変更。
現状提供しているPublicAPIは Convert のみなので、Convertの関数が受け付ける構造体以外は非公開にしても影響がない。
というのも、構造体や型だけ定義されているけれど、使い道が無いので、使う人もいないだろうと。