### PR TITLE
名詞「草」を「ハーブ」に変換するルールを追加いたしましたわ

### DIFF
--- a/ojosama_test.go
+++ b/ojosama_test.go
@@ -348,6 +348,13 @@ func TestConvert(t *testing.T) {
 			opt:     nil,
 			wantErr: false,
 		},
+		{
+			desc:    "正常系: 「草」は「おハーブ」に変換いたしますわ",
+			src:     "草",
+			want:    "おハーブ",
+			opt:     nil,
+			wantErr: false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/rule.go
+++ b/rule.go
@@ -903,6 +903,19 @@ var (
 			},
 			Value: "ほほほ",
 		},
+		{
+			Conditions: []convertCondition{
+				{
+					Type:  convertTypeFeatures,
+					Value: []string{"名詞", "一般"},
+				},
+				{
+					Type:  convertTypeSurface,
+					Value: []string{"草"},
+				},
+			},
+			Value: "ハーブ",
+		},
 	}
 )
 


### PR DESCRIPTION
素敵なおツールの公開、ありがとうございますわ！

おコードを拝見しましたところ、簡単に「草」を「ハーブ」に変換できそうだったので対応してみましたわ。
これで「草」をお上品な「おハーブ」に変換できるはずですわ。

私も二次創作おガイドラインは一通り読みましたわ。
おコントリビュートが同ガイドラインに違反しないとは思うのですが、間違いや趣旨の違いがあったらRejectしてくださいまし。