### PR TITLE
✨「皆様方」に変換するルールを追加いたしましたわ (close #11)

### DIFF
--- a/ojosama.go
+++ b/ojosama.go
@@ -77,10 +77,7 @@ func Convert(src string, opt *ConvertOption) (string, error) {
 		}
 
 		// お嬢様言葉に変換
-		buf = convert(data, tokens, i, buf, opt)
-
-		// 手前に「お」をつける。
-		buf, nounKeep = appendPrefix(data, tokens, i, buf, nounKeep)
+		buf, nounKeep = convert(data, tokens, i, buf, nounKeep, opt)
 
 		// 形容詞、自立で文が終わった時は丁寧語ですわを追加する
 		buf = appendPoliteWord(data, tokens, i, buf)
@@ -146,7 +143,7 @@ excludeLoop:
 }
 
 // convert は基本的な変換を行う。
-func convert(data tokenizer.TokenData, tokens []tokenizer.Token, i int, surface string, opt *ConvertOption) string {
+func convert(data tokenizer.TokenData, tokens []tokenizer.Token, i int, surface string, nounKeep bool, opt *ConvertOption) (string, bool) {
 	var beforeToken tokenizer.TokenData
 	var beforeTokenOK bool
 	if 0 < i {
@@ -190,9 +187,18 @@ func convert(data tokenizer.TokenData, tokens []tokenizer.Token, i int, surface 
 			result = appendLongNote(result, tokens, i, opt)
 		}
 
-		return result
+		// 手前に「お」を付ける
+		if !c.DisablePrefix {
+			result, nounKeep = appendPrefix(data, tokens, i, result, nounKeep)
+		}
+
+		return result, nounKeep
 	}
-	return surface
+
+	// 手前に「お」を付ける
+	result := surface
+	result, nounKeep = appendPrefix(data, tokens, i, result, nounKeep)
+	return result, nounKeep
 }
 
 // appendPrefix は surface の前に「お」を付ける。

--- a/ojosama_test.go
+++ b/ojosama_test.go
@@ -348,6 +348,13 @@ func TestConvert(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			desc:    "正常系: パパはおパパ上、ママはおママ上とお呼びいたしますわ",
+			src:     "皆、皆様",
+			want:    "皆様方、皆様方",
+			opt:     nil,
+			wantErr: false,
+		},
+		{
 			desc:    "正常系: 罵倒には「お」を付けませんのよ",
 			src:     "カス",
 			want:    "カス",

--- a/rule.go
+++ b/rule.go
@@ -11,6 +11,7 @@ type convertRule struct {
 	AfterIgnoreConditions        convertConditions // 次のTokenで条件にマッチした場合は無視する
 	EnableWhenSentenceSeparation bool              // 文の区切り（単語の後に句点か読点がくる、あるいは何もない）場合だけ有効にする
 	AppendLongNote               bool              // 波線を追加する
+	DisablePrefix                bool              // 「お」を手前に付与しない
 	Value                        string
 }
 
@@ -166,6 +167,8 @@ var (
 			},
 			Value: "ママ上",
 		},
+		newRulePronounGeneral("皆", "皆様方"),
+		newRuleNounsGeneral("皆様", "皆様方").disablePrefix(true),
 
 		// こそあど言葉
 		newRulePronounGeneral("これ", "こちら"),
@@ -622,4 +625,9 @@ func newRuleAdjectivesSelfSupporting(surface, value string) convertRule {
 
 func newRuleVerbs(surface, value string) convertRule {
 	return newRule(verbs, surface, value)
+}
+
+func (c convertRule) disablePrefix(v bool) convertRule {
+	c.DisablePrefix = v
+	return c
 }


### PR DESCRIPTION
「皆様」については「お」を付与する設定が干渉しておりましたので、（お皆様方）
`DisablePrefix` パラメータを設定していると明示的に「お」を付与しない制御をできるようにしましたわ～～！

close #11 